### PR TITLE
Update ref + fix typo

### DIFF
--- a/research.html
+++ b/research.html
@@ -77,14 +77,14 @@
                     </h3>
                     <ul class="w3-center">
                         <li class="w3-padding-16" style="text-align:justify"> <b>Martínez-Moreno, J.</b>, Hogg, A. McC., England, M. H., (2021). A near-global
-                            2 climatology of oceanic coherent eddies (JGR-Oceans) 
+                            climatology of oceanic coherent eddies (JGR-Oceans) 
                             </li>
                     </ul>
                     <h3 class="w3-center  w3-padding-32">
                         <p class="trn">Press</p>
                     </h3>
                     <ul class="w3-center">
-                        <li class="w3-padding-16" style="text-align:justify"> <b>Martínez-Moreno, J.</b>, Hogg, A. McC., England, M. H., Constantinou, N. C., Kiss, A. E., and Morrison, A. K. (2021). Global changes in oceanic mesoscale currents over the satellite altimetry record. Nature Climate Change (to appear) 
+                        <li class="w3-padding-16" style="text-align:justify"> <b>Martínez-Moreno, J.</b>, Hogg, A. McC., England, M. H., Constantinou, N. C., Kiss, A. E., and Morrison, A. K. (2021). Global changes in oceanic mesoscale currents over the satellite altimetry record. Nat. Clim. Chang., 11, 397–403.
                             <a href="https://doi.org/10.1038/s41558-021-01006-9" target="_blank"><span class="paper_button doi_button w3-round" style="font-family:sans-serif;">doi</span></a>
                             <a href="https://www.researchsquare.com/article/rs-88932/v1" target="_blank"><span class="paper_button pdf_button w3-round" style="font-family:sans-serif;">pdf</span></a>
                             <div class='altmetric-embed' data-badge-popover='bottom' data-doi='10.1038/s41558-021-01006-9' style="display: inline; vertical-align: text-bottom"></div>


### PR DESCRIPTION
Why do you give a link for the NCC paper to the archaic version submitted in Oct 2020? Link the latest version.